### PR TITLE
(fix) add missing 'watchify' npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-connect": "^2.2.0",
     "react": "^0.12.0",
     "reactify": "^0.16.0",
-    "vinyl-source-stream": "^1.0.0"
+    "vinyl-source-stream": "^1.0.0",
+    "watchify": "^2.1.1"
   }
 }


### PR DESCRIPTION
Running "gulp" for the first time causes an error, saying that 'watchify' is missing. I added it to the package.json file.
