### PR TITLE
(fix) add missing box prop to step3

### DIFF
--- a/steps/step3.jsx
+++ b/steps/step3.jsx
@@ -14,4 +14,4 @@ var Box = React.createClass({
 });
 
 
-React.render(<Box/>, document.body);
+React.render(<Box value='X'/>, document.body);


### PR DESCRIPTION
the "value" prop was added in step2, and is also in step4, but for some reason is missing from step3. As far as I can tell, this is an omission.
